### PR TITLE
fixed minor error with checking duplicate date in checkDuplicates

### DIFF
--- a/source/prototyping/saved-readings-script.js
+++ b/source/prototyping/saved-readings-script.js
@@ -214,7 +214,7 @@ function checkDuplicate(fortune) {
 	// to the passed in fortune
 	for (let i = 0; i < savedFortunes.length; i++) {
 		// Convert saved date to modified date string for equal comparisons
-		let modifiedDate = savedFortunes[i][2].toLocaleDateString(undefined, {
+		let modifiedDate = new Date(savedFortunes[i][2]).toLocaleDateString(undefined, {
 			weekday: "long",
 			year: "numeric",
 			month: "long",


### PR DESCRIPTION
The original code was trying to do `toLocaleDateString(....)` on `savedFortunes[i][2]`, but `savedFortunes[i][2]` is not a Date object in Javascript. Changing it to `new Date(savedFortunes[i][2]).toLocaleDateString(....)` fixed the equality checking.