### PR TITLE
Fixed Landing Page Zoom Animation

### DIFF
--- a/source/fortune-telling/landing-script.js
+++ b/source/fortune-telling/landing-script.js
@@ -45,10 +45,8 @@ function enterHut() {
     /* Clear all elements from page */
     pageContents.innerHTML = '';
 
-    /* Move background to line up with the hut door */
-    hutBackground.style.backgroundPosition = '50% 77.5%';
-    /* Zoom into the background image by 800% in 2 seconds */
-    hutBackground.style.backgroundSize = '1200%';
+    /* Call the entering hut animation */
+    hutBackground.style.animation= "zoom 2s forwards";
 }
 
 /* Add the listener to the landing page button */

--- a/source/fortune-telling/landing-script.js
+++ b/source/fortune-telling/landing-script.js
@@ -1,9 +1,10 @@
 /**
  * @file Script to control the landing page's functionality including the zoom 
- * in animation to enter the hut. - Last Modified: 06/06/2023
+ * in animation to enter the hut. - Last Modified: 06/11/2023
  * @author Nakul Nandhakumar
  * @author Joshua Tan
  * @author Abijit Jayachandran
+ * @author Helen Lin
  */
 
 /**

--- a/source/fortune-telling/landing-style.css
+++ b/source/fortune-telling/landing-style.css
@@ -35,10 +35,10 @@ html {
         background-size: 100% 100%;
     }
     to {
-        -webkit-background-size: 1200% 1200%;
-        -moz-background-size: 1200% 1200%;
-        -o-background-size: 1200% 1200%;
-        background-size: 1200% 1200%;
+        -webkit-background-size: 800% 1200%;
+        -moz-background-size: 800% 1200%;
+        -o-background-size: 800% 1200%;
+        background-size: 800% 1200%;
         background-position: 50% 80%;
     }
   }

--- a/source/fortune-telling/landing-style.css
+++ b/source/fortune-telling/landing-style.css
@@ -20,7 +20,7 @@ html {
     -webkit-background-size: 80%;
     -moz-background-size: 80%;
     -o-background-size: 80%;
-    background-size: 80%;
+    background-size: cover;
     background-color: rgb(2, 31, 2); /*change background color to match hut picture */
 
     /* position transitions take 1 second and size transitions take 2 seconds and are linear */

--- a/source/fortune-telling/landing-style.css
+++ b/source/fortune-telling/landing-style.css
@@ -17,6 +17,9 @@ body, h1, p {
 /* Adds background picture of hut and change background colour to match*/ 
 html {
     background: url(assets/landing-page/backdrop.png) no-repeat center center fixed;
+    -webkit-background-size: cover;
+    -moz-background-size: cover;
+    -o-background-size: cover;
     background-size: cover;
     background-color: rgb(2, 31, 2); /*change background color to match hut picture */
 }
@@ -26,10 +29,16 @@ html {
     from {
         /* Switch from cover to 100% 100%
            because cover doesn't work with animation */
+        -webkit-background-size:  100% 100%;
+        -moz-background-size:  100% 100%;
+        -o-background-size:  100% 100%;
         background-size: 100% 100%;
     }
     to {
-        background-size: 1000% 1200%;
+        -webkit-background-size: 1200% 1200%;
+        -moz-background-size: 1200% 1200%;
+        -o-background-size: 1200% 1200%;
+        background-size: 1200% 1200%;
         background-position: 50% 80%;
     }
   }

--- a/source/fortune-telling/landing-style.css
+++ b/source/fortune-telling/landing-style.css
@@ -17,18 +17,23 @@ body, h1, p {
 /* Adds background picture of hut and change background colour to match*/ 
 html {
     background: url(assets/landing-page/backdrop.png) no-repeat center center fixed;
-    -webkit-background-size: 80%;
-    -moz-background-size: 80%;
-    -o-background-size: 80%;
     background-size: cover;
     background-color: rgb(2, 31, 2); /*change background color to match hut picture */
-
-    /* position transitions take 1 second and size transitions take 2 seconds and are linear */
-    -webkit-transition: background-position 1s, background-size 1.5s linear;
-    -moz-transition: background-position 1s, background-size 1.5s linear;
-    -o-transition: background-position 1s, background-size 1.5s linear;
-    transition: background-position 1s, background-size 1.5s linear; 
 }
+
+/* Animation for entering the hut */
+@keyframes zoom {
+    from {
+        /* Switch from cover to 100% 100%
+           because cover doesn't work with animation */
+        background-size: 100% 100%;
+    }
+    to {
+        background-size: 1000% 1200%;
+        background-position: 50% 80%;
+    }
+  }
+
   
 /* Styles the header */
 header {


### PR DESCRIPTION
Re-implemented landing page zoom animation. 
- #189 

- Animation was not working when background-size set to cover.
- Changed to use CSS Animation
- Note: because the animation jumps from background-size: cover to background-size: 100% 100% there is a bit of a jump and the image is slightly different depnding on screen size. 
